### PR TITLE
Prepare UMD builds

### DIFF
--- a/packages/widget-core/package.json
+++ b/packages/widget-core/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "dist/widget-core.cjs.js",
   "module": "dist/widget-core.esm.js",
+  "unpkg": "dist/widget-core.umd.js",
   "types": "dist/widget-core.d.ts",
   "keywords": [],
   "author": "",

--- a/packages/widget-core/rollup.config.js
+++ b/packages/widget-core/rollup.config.js
@@ -25,6 +25,11 @@ export default defineConfig([
 				file: pkg.module,
 				format: 'esm',
 			},
+			{
+				file: pkg.unpkg,
+				format: 'umd',
+				name: 'LiveChatWidgetCore',
+			},
 		],
 	},
 	{

--- a/packages/widget-react/example/umd.html
+++ b/packages/widget-react/example/umd.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>React Sandbox</title>
+		<script src="https://unpkg.com/react@17.0.0/umd/react.production.min.js"></script>
+		<script src="https://unpkg.com/react-dom@17.0.0/umd/react-dom.production.min.js"></script>
+		<script src="widget-core.umd.js"></script>
+		<script src="widget-react.umd.js"></script>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script>
+			ReactDOM.render(
+				React.createElement(LiveChatWidgetReact.LiveChatWidget, { license: '12332502' }, null),
+				document.getElementById('root'),
+			)
+		</script>
+	</body>
+</html>

--- a/packages/widget-react/package.json
+++ b/packages/widget-react/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "dist/widget-react.cjs.js",
   "module": "dist/widget-react.esm.js",
+  "unpkg": "dist/widget-react.umd.js",
   "types": "dist/widget-react.d.ts",
   "keywords": [],
   "author": "",

--- a/packages/widget-react/rollup.config.js
+++ b/packages/widget-react/rollup.config.js
@@ -26,6 +26,15 @@ export default defineConfig([
 				file: pkg.main,
 				format: 'cjs',
 			},
+			{
+				file: pkg.unpkg,
+				format: 'umd',
+				name: 'LiveChatWidgetReact',
+				globals: {
+					react: 'React',
+					'@livechat/widget-core': 'LiveChatWidgetCore',
+				},
+			},
 		],
 	},
 	{

--- a/packages/widget-vue/example/umd.html
+++ b/packages/widget-vue/example/umd.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" href="/favicon.ico" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Vue Sandbox</title>
+		<script src="https://unpkg.com/vue@3.2.22"></script>
+		<script src="widget-core.umd.js"></script>
+		<script src="widget-vue.umd.js"></script>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script>
+			Vue.createApp(LiveChatWidgetVue.LiveChatWidget, {
+				license: '12332502',
+				visibility: 'maximized',
+			}).mount('#app')
+		</script>
+	</body>
+</html>

--- a/packages/widget-vue/package.json
+++ b/packages/widget-vue/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "dist/widget-vue.cjs.js",
   "module": "dist/widget-vue.esm.js",
+  "unpkg": "dist/widget-vue.umd.js",
   "types": "dist/widget-vue.d.ts",
   "keywords": [],
   "author": "",

--- a/packages/widget-vue/rollup.config.js
+++ b/packages/widget-vue/rollup.config.js
@@ -26,6 +26,15 @@ export default defineConfig([
 				file: pkg.module,
 				format: 'esm',
 			},
+			{
+				file: pkg.unpkg,
+				format: 'umd',
+				name: 'LiveChatWidgetVue',
+				globals: {
+					vue: 'Vue',
+					'@livechat/widget-core': 'LiveChatWidgetCore',
+				},
+			},
 		],
 	},
 	{


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [ ] Bug fix
- [x] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [x] @livechat/widget-core
- [x] @livechat/widget-react
- [x] @livechat/widget-vue
- [ ] @livechat/widget-angular

### Issue

N/A

### Description

React and Vue allows to be used from their UMD build and fetched directly from the `script` tag in HTML. Prepare UMD builds for corresponding packages to allow using those adapters and core package via `script` tag.

#### @livechat/widget-react
![image](https://user-images.githubusercontent.com/9700566/145280403-66ee1ef2-f717-4f44-9463-f291f79d9881.png)

#### @livechat/widget-vue
![image](https://user-images.githubusercontent.com/9700566/145280419-ba105366-d244-40ac-91ff-81f5e15257dd.png)
