### PR TITLE
Enable TS config isolated modules

### DIFF
--- a/packages/widget-angular/src/WidgetChatData.service.ts
+++ b/packages/widget-angular/src/WidgetChatData.service.ts
@@ -3,7 +3,7 @@ import { Injectable, NgZone, OnDestroy } from '@angular/core'
 import { getData } from '@livechat/widget-core'
 import type { ChatData } from '@livechat/widget-core'
 
-import { WidgetCustomerDataService } from './WidgetCustomerData.service'
+import type { WidgetCustomerDataService } from './WidgetCustomerData.service'
 
 @Injectable()
 export class WidgetChatDataService implements OnDestroy {

--- a/packages/widget-angular/tsconfig.json
+++ b/packages/widget-angular/tsconfig.json
@@ -9,6 +9,8 @@
     "experimentalDecorators": true,
     "outDir": "lib",
     "declaration": true,
+    "isolatedModules": true,
+    "importsNotUsedAsValues": "error",
     "paths": {
       "@livechat/widget-core": [
         "../widget-core"

--- a/packages/widget-core/tsconfig.json
+++ b/packages/widget-core/tsconfig.json
@@ -12,6 +12,8 @@
     "emitDeclarationOnly": true,
     "declarationDir": "dist",
     "target": "ESNext",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "importsNotUsedAsValues": "error"
   }
 }

--- a/packages/widget-react/tsconfig.json
+++ b/packages/widget-react/tsconfig.json
@@ -15,6 +15,8 @@
     "declarationDir": "dist",
     "target": "ESNext",
     "moduleResolution": "node",
+    "isolatedModules": true,
+    "importsNotUsedAsValues": "error",
     "paths": {
       "@livechat/widget-core": [
         "../widget-core"

--- a/packages/widget-vue/tsconfig.json
+++ b/packages/widget-vue/tsconfig.json
@@ -13,6 +13,8 @@
     "declarationDir": "dist",
     "target": "ESNext",
     "moduleResolution": "node",
+    "isolatedModules": true,
+    "importsNotUsedAsValues": "error",
     "paths": {
       "@livechat/widget-core": [
         "../widget-core"


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [ ] Bug fix
- [x] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [x] @livechat/widget-core
- [x] @livechat/widget-react
- [x] @livechat/widget-vue
- [x] @livechat/widget-angular

### Issue

N/A

### Description

Enable TS config `isolatedModules` to align with single file processing done by Babel which is used in packages build pipeline. Additionally set `importsNotUsedAsValues` to `"error"` to force `import type` keyword for type only imports.