### PR TITLE
Mark packages as side effects free

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@livechat/chat-widget
+* @livechat/chat-widget

--- a/packages/widget-angular/package.json
+++ b/packages/widget-angular/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@livechat/widget-angular",
   "version": "1.0.0",
+  "sideEffects": false,
   "description": "This library allows to render and interact with the LiveChat Chat Widget inside an Angular application",
   "main": "dist/widget-angular.cjs.js",
   "module": "dist/widget-angular.esm.js",

--- a/packages/widget-core/package.json
+++ b/packages/widget-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@livechat/widget-core",
   "version": "1.0.0",
+  "sideEffects": false,
   "description": "LiveChat Chat Widget adapters implementation core",
   "main": "dist/widget-core.cjs.js",
   "module": "dist/widget-core.esm.js",

--- a/packages/widget-react/package.json
+++ b/packages/widget-react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@livechat/widget-react",
   "version": "1.0.0",
+  "sideEffects": false,
   "description": "This library allows to render and interact with the LiveChat Chat Widget inside a React application",
   "main": "dist/widget-react.cjs.js",
   "module": "dist/widget-react.esm.js",

--- a/packages/widget-vue/package.json
+++ b/packages/widget-vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@livechat/widget-vue",
   "version": "1.0.0",
+  "sideEffects": false,
   "description": "This library allows to render and interact with the LiveChat Chat Widget inside a Vue 3 application",
   "main": "dist/widget-vue.cjs.js",
   "module": "dist/widget-vue.esm.js",


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [ ] Docs
- [ ] Bug fix
- [x] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [x] @livechat/widget-core
- [x] @livechat/widget-react
- [x] @livechat/widget-vue
- [x] @livechat/widget-angular

### Issue

N/A

### Description

Mark packages as side effects free to allow builders like [Webpack to better tree shake](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) adapters packages.
