### PR TITLE
Vue 2 partial support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+v2
 build
 lib
 dts

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+v2
 dts
 lib
 .DS_Store

--- a/packages/widget-vue/README.md
+++ b/packages/widget-vue/README.md
@@ -1,6 +1,6 @@
 # @livechat/widget-vue
 
-> This library allows to render and interact with the [LiveChat Chat Widget](https://developers.livechat.com/open-chat-widget/) inside a [Vue 3](https://v3.vuejs.org/) application.
+> This library allows to render and interact with the [LiveChat Chat Widget](https://developers.livechat.com/open-chat-widget/) inside a [Vue](https://vuejs.org/) application.
 
 [![mit](https://img.shields.io/badge/license-MIT-blue.svg)](https://choosealicense.com/licenses/mit/)
 ![Github lerna version](https://img.shields.io/github/lerna-json/v/livechat/chat-widget-adapters?label=version)
@@ -25,6 +25,8 @@ yarn add @livechat/widget-vue
 
 ### Render
 
+#### Vue 3
+
 ```html
 <script lang="ts" setup>
   import { LiveChatWidget, EventHandlerPayload } from '@livechat/widget-vue'
@@ -41,6 +43,34 @@ yarn add @livechat/widget-vue
     v-on:new-event="handleNewEvent"
   />
 </template>
+```
+
+#### Vue 2
+
+```html
+<template>
+  <LiveChatWidget
+    license="12345678"
+    visibility="maximized"
+    v-on:new-event="handleNewEvent"
+  />
+</template>
+
+<script>
+  import { LiveChatWidget } from '@livechat/widget-vue/v2'
+
+  export default {
+    name: 'App',
+    components: {
+      LiveChatWidget,
+    },
+    methods: {
+      handleNewEvent(event) {
+        console.log('LiveChatWidget.onNewEvent', event)
+      },
+    },
+  }
+</script>
 ```
 
 ### Props
@@ -78,6 +108,8 @@ All event handlers listed below are registered if provided for the first time. T
 ### Composition API
 
 This package exports a set of [Vue Composition API](https://v3.vuejs.org/api/composition-api.html#composition-api) utilities that allow consuming reactive data from the chat widget in any place of the application as long as the `LiveChatWidget` component is rendered in the tree.
+
+**The composition API is only availble for Vue 3 apps.**
 
 #### useWidgetState
 

--- a/packages/widget-vue/package.json
+++ b/packages/widget-vue/package.json
@@ -17,19 +17,22 @@
     "url": "https://github.com/livechat/chat-widget-adapters.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "v2"
   ],
   "scripts": {
     "test": "jest",
     "coverage": "jest --coverage",
-    "build": "rimraf dist && rollup -c",
-    "start": "rollup -c -w"
+    "start": "rollup -c -w",
+    "build": "run-p build:*",
+    "build:default": "rimraf dist && rollup -c",
+    "build:vue2": "rimraf v2 && rollup -c rollup-vue2.config.js"
   },
   "dependencies": {
     "@livechat/widget-core": "^1.0.1"
   },
   "peerDependencies": {
-    "vue": "3"
+    "vue": "2 || 3"
   },
   "devDependencies": {
     "eslint-plugin-vue": "8.1.1",

--- a/packages/widget-vue/rollup-vue2.config.js
+++ b/packages/widget-vue/rollup-vue2.config.js
@@ -2,11 +2,16 @@ import fs from 'fs'
 import { defineConfig } from 'rollup'
 import resolve from '@rollup/plugin-node-resolve'
 import babel from '@rollup/plugin-babel'
+import replace from '@rollup/plugin-replace'
+import { terser } from 'rollup-plugin-terser'
+
+import mainPkg from './package.json'
 
 const extensions = ['.ts']
 const pkg = {
 	main: 'LiveChatWidget.cjs.js',
 	module: 'LiveChatWidget.esm.js',
+	unpkg: 'LiveChatWidget.umd.js',
 }
 
 /**
@@ -78,6 +83,7 @@ export default defineConfig({
 	external: ['vue', '@livechat/widget-core'],
 	plugins: [
 		resolve({ extensions }),
+		replace({ 'process.env.PACKAGE_NAME': JSON.stringify(`${String(mainPkg.name)}/v2`), preventAssignment: true }),
 		babel({ extensions, babelHelpers: 'bundled', plugins: [removeVueDefineComponentCall] }),
 		makePkgJSON(),
 	],
@@ -89,6 +95,16 @@ export default defineConfig({
 		{
 			file: `v2/${pkg.main}`,
 			format: 'cjs',
+		},
+		{
+			file: `v2/${pkg.unpkg}`,
+			format: 'umd',
+			name: 'LiveChatWidgetVue',
+			plugins: [terser()],
+			globals: {
+				vue: 'Vue',
+				'@livechat/widget-core': 'LiveChatWidgetCore',
+			},
 		},
 	],
 })

--- a/packages/widget-vue/rollup-vue2.config.js
+++ b/packages/widget-vue/rollup-vue2.config.js
@@ -1,0 +1,94 @@
+import fs from 'fs'
+import { defineConfig } from 'rollup'
+import resolve from '@rollup/plugin-node-resolve'
+import babel from '@rollup/plugin-babel'
+
+const extensions = ['.ts']
+const pkg = {
+	main: 'LiveChatWidget.cjs.js',
+	module: 'LiveChatWidget.esm.js',
+}
+
+/**
+ * Babel plugin
+ *  1. Removes `defineComponent` import declarations:
+ *    a. `import { defineComponent } from 'vue'` => no import
+ *    b. `import Vue, { defineComponent } from 'vue'` => `import Vue from 'vue'`
+ *    c. `import { defineComponent, createApp } from 'vue'` => `import { createApp } from 'vue'`
+ *
+ *  3. Replaces `defineComponent` call with its first argument, for example:
+ *    a. `defineComponent({ template: '', props: {} })` => `{ template: '', props: {} }`
+ *    b. `export const Component = defineComponent({})` => `export const Component = {}`
+ */
+function removeVueDefineComponentCall() {
+	return {
+		visitor: {
+			Program(path) {
+				path.setData('calleeName', [])
+				path.traverse({
+					ImportDeclaration(_path) {
+						if (_path.get('importKind').node !== 'value' || _path.get('source.value').node !== 'vue') {
+							return
+						}
+
+						_path.setData('newSpecifiers', [])
+						_path.traverse({
+							'ImportSpecifier|ImportDefaultSpecifier'(__path) {
+								if (__path.get('imported.name').node === 'defineComponent') {
+									path.setData('calleeName', path.getData('calleeName').concat(__path.get('local.name').node))
+								} else {
+									_path.setData('newSpecifiers', _path.getData('newSpecifiers').concat(__path.node))
+								}
+							},
+						})
+
+						if (_path.getData('newSpecifiers').length === 0) {
+							_path.remove()
+						} else {
+							_path.set('specifiers', _path.getData('newSpecifiers'))
+						}
+					},
+					CallExpression(_path) {
+						if (path.getData('calleeName').includes(_path.get('callee.name').node)) {
+							_path.replaceWith(_path.get('arguments.0').node)
+						}
+					},
+				})
+			},
+		},
+	}
+}
+
+/**
+ * Rollup plugin
+ *  1. Makes new 'v2' directory where build outputs will be stored
+ *  2. Adds 'package.json' pointing to apropriate build output formats
+ */
+function makePkgJSON() {
+	return {
+		buildEnd() {
+			fs.mkdirSync('v2')
+			fs.writeFileSync('v2/package.json', JSON.stringify(pkg, null, 2))
+		},
+	}
+}
+
+export default defineConfig({
+	input: 'src/LiveChatWidget.ts',
+	external: ['vue', '@livechat/widget-core'],
+	plugins: [
+		resolve({ extensions }),
+		babel({ extensions, babelHelpers: 'bundled', plugins: [removeVueDefineComponentCall] }),
+		makePkgJSON(),
+	],
+	output: [
+		{
+			file: `v2/${pkg.module}`,
+			format: 'esm',
+		},
+		{
+			file: `v2/${pkg.main}`,
+			format: 'cjs',
+		},
+	],
+})

--- a/packages/widget-vue/src/LiveChatWidget.ts
+++ b/packages/widget-vue/src/LiveChatWidget.ts
@@ -1,5 +1,4 @@
 import { defineComponent } from 'vue'
-import type { PropType } from 'vue'
 import { createWidget } from '@livechat/widget-core'
 import type { ExtendedWindow, WidgetInstance, WidgetConfig, CustomerData, WidgetState } from '@livechat/widget-core'
 
@@ -8,40 +7,52 @@ declare const window: ExtendedWindow
 export const LiveChatWidget = defineComponent({
 	props: {
 		license: {
-			type: Object as PropType<WidgetConfig['license']>,
+			type: String,
 			required: true,
 		},
 		group: {
-			type: Object as PropType<WidgetConfig['group']>,
+			type: String,
 			required: false,
 			default: undefined,
 		},
 		visibility: {
-			type: Object as PropType<WidgetConfig['visibility']>,
+			type: String,
 			required: false,
 			default: undefined,
 		},
 		customerName: {
-			type: Object as PropType<WidgetConfig['customerName']>,
+			type: String,
 			required: false,
 			default: undefined,
 		},
 		customerEmail: {
-			type: Object as PropType<WidgetConfig['customerEmail']>,
+			type: String,
 			required: false,
 			default: undefined,
 		},
 		sessionVariables: {
-			type: Object as PropType<WidgetConfig['sessionVariables']>,
+			type: Object,
 			required: false,
 			default: undefined,
 		},
 		chatBetweenGroups: {
-			type: Object as PropType<WidgetConfig['chatBetweenGroups']>,
+			type: Boolean,
 			required: false,
 			default: undefined,
 		},
 	},
+	emits: [
+		'ready',
+		'new-event',
+		'form-submitted',
+		'rating-submitted',
+		'greeting-hidden',
+		'greeting-displayed',
+		'visibility-changed',
+		'customer-status-changed',
+		'rich-message-button-clicked',
+		'availability-changed',
+	],
 	data(): { widget: WidgetInstance | null } {
 		return {
 			widget: null,
@@ -72,25 +83,24 @@ export const LiveChatWidget = defineComponent({
 	},
 	methods: {
 		setupWidget() {
-			const emit = this.$emit
 			this.widget = createWidget({
 				group: this.group,
 				license: this.license,
-				visibility: this.visibility,
 				customerName: this.customerName,
 				customerEmail: this.customerEmail,
 				sessionVariables: this.sessionVariables,
 				chatBetweenGroups: this.chatBetweenGroups,
-				onReady: (data) => emit('ready', data),
-				onNewEvent: (event) => emit('new-event', event),
-				onFormSubmitted: (form) => emit('form-submitted', form),
-				onRatingSubmitted: (rating) => emit('rating-submitted', rating),
-				onGreetingHidden: (greeting) => emit('greeting-hidden', greeting),
-				onGreetingDisplayed: (greeting) => emit('greeting-displayed', greeting),
-				onVisibilityChanged: (visibility) => emit('visibility-changed', visibility),
-				onCustomerStatusChanged: (status) => emit('customer-status-changed', status),
-				onRichMessageButtonClicked: (button) => emit('rich-message-button-clicked', button),
-				onAvailabilityChanged: (availability) => emit('availability-changed', availability),
+				visibility: this.visibility as WidgetConfig['visibility'],
+				onReady: (data) => this.$emit('ready', data),
+				onNewEvent: (event) => this.$emit('new-event', event),
+				onFormSubmitted: (form) => this.$emit('form-submitted', form),
+				onRatingSubmitted: (rating) => this.$emit('rating-submitted', rating),
+				onGreetingHidden: (greeting) => this.$emit('greeting-hidden', greeting),
+				onGreetingDisplayed: (greeting) => this.$emit('greeting-displayed', greeting),
+				onVisibilityChanged: (visibility) => this.$emit('visibility-changed', visibility),
+				onCustomerStatusChanged: (status) => this.$emit('customer-status-changed', status),
+				onRichMessageButtonClicked: (button) => this.$emit('rich-message-button-clicked', button),
+				onAvailabilityChanged: (availability) => this.$emit('availability-changed', availability),
 			})
 			window.__lc.integration_name = process.env.PACKAGE_NAME
 			this.widget.init()
@@ -99,5 +109,8 @@ export const LiveChatWidget = defineComponent({
 			this.widget?.destroy()
 			this.setupWidget()
 		},
+	},
+	render() {
+		return null
 	},
 })


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [x] Docs
- [ ] Bug fix
- [x] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [ ] @livechat/widget-core
- [ ] @livechat/widget-react
- [x] @livechat/widget-vue
- [ ] @livechat/widget-angular

### Issue

Resolves https://github.com/livechat/chat-widget-adapters/issues/27

### Description

Add partial support for Vue 2 by exporting additional submodule `v2` which exports the` LiveChatWidget` component compatible with Vue 2. The "hooks" using Composition API will still be Vue 3 exclusive feature as the overall Composition API is a new feature since version 3. 

The usage in Vue 2 app is as follows:
```html
<template>
  <LiveChatWidget
    license="12345678"
    visibility="maximized"
    v-on:new-event="handleNewEvent"
  />
</template>

<script>
  import { LiveChatWidget } from '@livechat/widget-vue/v2'

  export default {
    name: 'App',
    components: {
      LiveChatWidget,
    },
    methods: {
      handleNewEvent(event) {
        console.log('LiveChatWidget.onNewEvent', event)
      },
    },
  }
</script>
```

To achieve compatibility with both Vue 2 and Vue 3 for `LiveChatWidget` component it is defined with an "old" Options API approach (as opposed to Composition API with [setup method](https://vuejs.org/api/composition-api-setup.html#composition-api-setup) or [setup script](https://vuejs.org/api/sfc-script-setup.html#script-setup)).

In order to resolve imports issues and no existence of `defineComponent` function in `vue@2` package but still offer to reach TypeScript support for Vue 3 there is a new dedicated build pipeline for Vue 2 submodule defined in `packages/widget-vue/rollup-vue2.config.js`. Aside from the typical Rollup configuration for input and output files, it includes a custom Babel plugin for removing imports and usages of `defineComponent` from the output file leaving plain object component definition as an export. That way it can be consumed by Vue 2 application without compatibility error. 

The `LiveChatWidget` component required some slight adjustments to be both compatible with Vue 2 and 3:
- Refactor prop types definitions from using `PropType` to type constructor (String, Object, Boolean etc.)
- Add `render()` methods that explicitly return nothing (`null`)
- Add `emits` property which contains a list of events that consumers can listen on this component.
- Use `this.emit$` directly in handlers and let Babel extract `this` reference binding.