### PR TITLE
Mention LiveChatWidgetModule import in Angular docs

### DIFF
--- a/packages/widget-angular/README.md
+++ b/packages/widget-angular/README.md
@@ -26,6 +26,19 @@ yarn add @livechat/widget-angular
 ### Render
 
 ```ts
+// app.module.ts
+
+import { NgModule } from '@angular/core'
+import { LiveChatWidgetModule } from '@livechat/widget-angular'
+
+@NgModule({
+  /* ... */
+  imports: [LiveChatWidgetModule],
+})
+export class AppModule {}
+```
+
+```ts
 // app.component.ts
 
 import { Component } from '@angular/core'


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [x] Docs
- [ ] Bug fix
- [ ] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [ ] @livechat/widget-core
- [ ] @livechat/widget-react
- [ ] @livechat/widget-vue
- [x] @livechat/widget-angular

### Issue

N/A

### Description

Mention LiveChatWidgetModule import in Angular docs inside usage example. As this is a crucial part of integrating the LiveChatWidget with the Angular application it should be explicitly showcased.
