### PR TITLE
Update package.json to allow angular 18

### DIFF
--- a/packages/widget-angular/package.json
+++ b/packages/widget-angular/package.json
@@ -30,7 +30,7 @@
     "@livechat/widget-core": "^1.3.2"
   },
   "peerDependencies": {
-    "@angular/core": "12 || 13 || 14 || 15 || 16 || 17",
+    "@angular/core": "12 || 13 || 14 || 15 || 16 || 17 || 18",
     "rxjs": "6 || 7"
   },
   "devDependencies": {


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [ ] Docs
- [ ] Bug fix
- [ ] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [ ] @livechat/widget-core
- [ ] @livechat/widget-react
- [ ] @livechat/widget-vue
- [x] @livechat/widget-angular

### Issue

<!-- Paste here link to the issue that is resolved or fixed by this PR -->

### Description

<!-- Describe what changes this PR introduce -->

Since angular 18 is released it should be allowed to use.
