### PR TITLE
Fix: explicitly navigate to chat view in e2e spec

### DIFF
--- a/e2e/example-page.ts
+++ b/e2e/example-page.ts
@@ -49,6 +49,10 @@ export class ExamplePage {
 		this.widgetFrame = await elementHandle.contentFrame()
 	}
 
+	async openChatView() {
+		await this.widgetFrame.locator('text=Chat now').click()
+	}
+
 	async startTheChat() {
 		const startTheChatButton = await this.widgetFrame.waitForSelector('text=Start the chat', {
 			state: 'visible',

--- a/e2e/examples.spec.ts
+++ b/e2e/examples.spec.ts
@@ -25,6 +25,7 @@ test.describe.parallel('Example applications', () => {
 			const examplePage = new ExamplePage(page, framework)
 			await examplePage.goto()
 			await examplePage.getWidgetIframe()
+			await examplePage.openChatView()
 
 			customerData.id = examplePage.getServerCustomerId()
 			await expect(examplePage.dataContainers.widgetIsReady).toHaveText('Widget is ready: true')


### PR DESCRIPTION
### Description

Adjust e2e spec after the recent release of Homescreen. Now in order to test Chat view content we need to first explicitly navigate to it before making any further assertions. This PR adds a simple `openChatView` method to the page model and calls it after navigating to a test page and obtaining the widget iframe reference. 
