### PR TITLE
Chore: bump GH Actions versions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,12 +9,12 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
-          cache: 'yarn'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "16"
+          cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
       - run: yarn
       - run: yarn run publish
         env:


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [ ] Docs
- [ ] Bug fix
- [ ] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [ ] @livechat/widget-core
- [ ] @livechat/widget-react
- [ ] @livechat/widget-vue
- [ ] @livechat/widget-angular

### Issue

<!-- Paste here link to the issue that is resolved or fixed by this PR -->

### Description

Chore: bump GH Actions versions in publish workflow
