### PR TITLE
Add internal env option for tracking.js URL

### DIFF
--- a/packages/widget-angular/src/LiveChatWidget.component.ts
+++ b/packages/widget-angular/src/LiveChatWidget.component.ts
@@ -1,4 +1,14 @@
-import { Component, Directive, Input, Output, OnInit, OnDestroy, OnChanges, EventEmitter } from '@angular/core'
+import {
+	Component,
+	Directive,
+	ElementRef,
+	Input,
+	Output,
+	OnInit,
+	OnDestroy,
+	OnChanges,
+	EventEmitter,
+} from '@angular/core'
 import { createWidget } from '@livechat/widget-core'
 import type {
 	ExtendedWindow,
@@ -17,15 +27,7 @@ type Changes = Partial<{
 		currentValue: WidgetConfig[key]
 		isFirstChange(): boolean
 	}
-}> &
-	Partial<{
-		env: {
-			firstChange: boolean
-			previousValue: string | undefined
-			currentValue: string | undefined
-			isFirstChange(): boolean
-		}
-	}>
+}>
 
 @Directive()
 abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
@@ -38,7 +40,6 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 	@Input() sessionVariables: WidgetConfig['sessionVariables']
 	@Input() chatBetweenGroups: WidgetConfig['chatBetweenGroups']
 	@Input() customIdentityProvider: WidgetConfig['customIdentityProvider']
-	@Input() env: string | undefined
 
 	@Output() onReady = new EventEmitter<EventHandlerPayload<'onReady'>>()
 	@Output() onNewEvent = new EventEmitter<EventHandlerPayload<'onNewEvent'>>()
@@ -54,18 +55,14 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 	widget: WidgetInstance | null = null
 	protected abstract product: ProductName
 
+	constructor(private elementRef: ElementRef<HTMLElement>) {}
+
 	ngOnInit() {
 		this.setupWidget()
 	}
 
 	ngOnChanges(changes: Changes) {
-		const fullReloadProps: Array<keyof WidgetConfig | 'env'> = [
-			'license',
-			'organizationId',
-			'group',
-			'chatBetweenGroups',
-			'env',
-		]
+		const fullReloadProps: Array<keyof WidgetConfig> = ['license', 'organizationId', 'group', 'chatBetweenGroups']
 		if (fullReloadProps.some((prop) => changes[prop] !== undefined && !changes[prop]?.isFirstChange())) {
 			this.reinitialize()
 			return
@@ -100,7 +97,8 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 			sessionVariables: this.sessionVariables,
 			chatBetweenGroups: this.chatBetweenGroups,
 			customIdentityProvider: this.customIdentityProvider,
-			env: this.env,
+			// env is internal: read from a host attribute so it never becomes an @Input
+			env: this.elementRef.nativeElement.getAttribute('env') ?? undefined,
 			onReady: (data) => this.onReady.emit(data),
 			onNewEvent: (event) => this.onNewEvent.emit(event),
 			onFormSubmitted: (form) => this.onFormSubmitted.emit(form),

--- a/packages/widget-angular/src/LiveChatWidget.component.ts
+++ b/packages/widget-angular/src/LiveChatWidget.component.ts
@@ -17,7 +17,15 @@ type Changes = Partial<{
 		currentValue: WidgetConfig[key]
 		isFirstChange(): boolean
 	}
-}>
+}> &
+	Partial<{
+		env: {
+			firstChange: boolean
+			previousValue: string | undefined
+			currentValue: string | undefined
+			isFirstChange(): boolean
+		}
+	}>
 
 @Directive()
 abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
@@ -30,6 +38,7 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 	@Input() sessionVariables: WidgetConfig['sessionVariables']
 	@Input() chatBetweenGroups: WidgetConfig['chatBetweenGroups']
 	@Input() customIdentityProvider: WidgetConfig['customIdentityProvider']
+	@Input() env: string | undefined
 
 	@Output() onReady = new EventEmitter<EventHandlerPayload<'onReady'>>()
 	@Output() onNewEvent = new EventEmitter<EventHandlerPayload<'onNewEvent'>>()
@@ -50,7 +59,13 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 	}
 
 	ngOnChanges(changes: Changes) {
-		const fullReloadProps: Array<keyof WidgetConfig> = ['license', 'organizationId', 'group', 'chatBetweenGroups']
+		const fullReloadProps: Array<keyof WidgetConfig | 'env'> = [
+			'license',
+			'organizationId',
+			'group',
+			'chatBetweenGroups',
+			'env',
+		]
 		if (fullReloadProps.some((prop) => changes[prop] !== undefined && !changes[prop]?.isFirstChange())) {
 			this.reinitialize()
 			return
@@ -75,7 +90,7 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 	}
 
 	setupWidget() {
-		this.widget = createWidget({
+		const config: WidgetConfig & { env?: string } = {
 			group: this.group,
 			license: this.license,
 			organizationId: this.organizationId,
@@ -85,6 +100,7 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 			sessionVariables: this.sessionVariables,
 			chatBetweenGroups: this.chatBetweenGroups,
 			customIdentityProvider: this.customIdentityProvider,
+			env: this.env,
 			onReady: (data) => this.onReady.emit(data),
 			onNewEvent: (event) => this.onNewEvent.emit(event),
 			onFormSubmitted: (form) => this.onFormSubmitted.emit(form),
@@ -95,7 +111,8 @@ abstract class BaseWidgetComponent implements OnInit, OnDestroy, OnChanges {
 			onCustomerStatusChanged: (status) => this.onCustomerStatusChanged.emit(status),
 			onRichMessageButtonClicked: (button) => this.onRichMessageButtonClicked.emit(button),
 			onAvailabilityChanged: (availability) => this.onAvailabilityChanged.emit(availability),
-		})
+		}
+		this.widget = createWidget(config)
 		window.__lc.integration_name = process.env.PACKAGE_NAME
 		if (this.product === 'textapp') {
 			window.__lc.product_name = 'text'

--- a/packages/widget-core/src/__tests__/create-js-api.spec.ts
+++ b/packages/widget-core/src/__tests__/create-js-api.spec.ts
@@ -3,6 +3,11 @@ import type { ExtendedWindow } from '../types'
 
 declare const window: ExtendedWindow
 
+afterEach(() => {
+	document.querySelectorAll('script').forEach((script) => script.remove())
+	delete (window as { LiveChatWidget?: unknown }).LiveChatWidget
+})
+
 test('createJSApi', () => {
 	createJSApi()
 	expect(window.LiveChatWidget).toMatchInlineSnapshot(`
@@ -18,4 +23,55 @@ test('createJSApi', () => {
 		  "once": [Function],
 		}
 	`)
+})
+
+describe('tracking script source', () => {
+	it('defaults to the production tracking script when no env is given', () => {
+		createJSApi()
+		window.LiveChatWidget.init()
+
+		expect(document.querySelector('script')?.src).toBe('https://cdn.livechatinc.com/tracking.js')
+	})
+
+	it('loads the production tracking script for env "production"', () => {
+		createJSApi('production')
+		window.LiveChatWidget.init()
+
+		expect(document.querySelector('script')?.src).toBe('https://cdn.livechatinc.com/tracking.js')
+	})
+
+	it('loads the labs tracking script for env "labs"', () => {
+		createJSApi('labs')
+		window.LiveChatWidget.init()
+
+		expect(document.querySelector('script')?.src).toBe('https://cdn.labs.livechatinc.com/tracking.js')
+	})
+
+	it('loads the staging tracking script for env "staging"', () => {
+		createJSApi('staging')
+		window.LiveChatWidget.init()
+
+		expect(document.querySelector('script')?.src).toBe('https://cdn.staging.livechatinc.com/tracking.js')
+	})
+
+	it('falls back to the production tracking script for an unknown env', () => {
+		createJSApi('unknown' as never)
+		window.LiveChatWidget.init()
+
+		expect(document.querySelector('script')?.src).toBe('https://cdn.livechatinc.com/tracking.js')
+	})
+
+	it('loads the new tracking script when reinitialized with a different env', () => {
+		// window.LiveChatWidget is only assigned once and never torn down between reinitializations
+		// (see the `||` guard in createJSApi), so this reproduces that scenario without the
+		// `afterEach` cleanup masking it.
+		createJSApi('labs')
+		window.LiveChatWidget.init()
+		document.querySelectorAll('script').forEach((script) => script.remove())
+
+		createJSApi('staging')
+		window.LiveChatWidget.init()
+
+		expect(document.querySelector('script')?.src).toBe('https://cdn.staging.livechatinc.com/tracking.js')
+	})
 })

--- a/packages/widget-core/src/__tests__/create-widget.spec.ts
+++ b/packages/widget-core/src/__tests__/create-widget.spec.ts
@@ -73,6 +73,12 @@ describe('createWidget', () => {
 		expect(window.__lc).toHaveProperty('integration_name')
 	})
 
+	it('should pass the env through to createJSApi', () => {
+		createWidget({ ...widgetConfig, env: 'labs' })
+
+		expect(mockCreateJSApi).toBeCalledWith('labs')
+	})
+
 	it('should handle init method', () => {
 		const widget: WidgetInstance = createWidget(widgetConfig)
 

--- a/packages/widget-core/src/create-js-api.ts
+++ b/packages/widget-core/src/create-js-api.ts
@@ -1,11 +1,23 @@
 /* eslint-disable prefer-rest-params, @typescript-eslint/no-explicit-any, @typescript-eslint/ban-ts-comment, @typescript-eslint/unbound-method */
-import type { ExtendedWindow } from './types'
+import type { ExtendedWindow, Env } from './types'
 
 declare const window: ExtendedWindow
 
 const scriptRef: { current: HTMLScriptElement | null } = { current: null }
 
-export function createJSApi() {
+const trackingScriptUrls: Record<Env, string> = {
+	production: 'https://cdn.livechatinc.com/tracking.js',
+	labs: 'https://cdn.labs.livechatinc.com/tracking.js',
+	staging: 'https://cdn.staging.livechatinc.com/tracking.js',
+}
+
+// window.LiveChatWidget is only assigned once (see the `||` guard below), so `init` must read
+// the env from this ref rather than close over the `env` argument - otherwise a reinitialize
+// with a different env would keep loading the tracking.js of the very first env.
+const envRef: { current: Env } = { current: 'production' }
+
+export function createJSApi(env: Env = 'production') {
+	envRef.current = env
 	const { slice } = Array.prototype
 
 	/* istanbul ignore next */
@@ -40,7 +52,7 @@ export function createJSApi() {
 			const script = document.createElement('script')
 			script.async = true
 			script.type = 'text/javascript'
-			script.src = 'https://cdn.livechatinc.com/tracking.js'
+			script.src = trackingScriptUrls[envRef.current] ?? trackingScriptUrls.production
 			document.head.appendChild(script)
 			scriptRef.current = script
 		},

--- a/packages/widget-core/src/create-widget.ts
+++ b/packages/widget-core/src/create-widget.ts
@@ -56,7 +56,7 @@ export function createWidget(config: WidgetConfig): WidgetInstance {
 		},
 	}
 
-	const scriptRef = createJSApi()
+	const scriptRef = createJSApi(config.env)
 	assignConfiguration(config)
 	assignVisibility(config.visibility)
 	assignEventHandlers('on', state.currentEventHandlers)

--- a/packages/widget-core/src/types.ts
+++ b/packages/widget-core/src/types.ts
@@ -59,6 +59,9 @@ export type CustomerData = MutableCustomerData & {
 	sessionVariables: Record<string, string>
 }
 
+/** @internal */
+export type Env = 'labs' | 'staging' | 'production'
+
 export type ConfigurationOptions = {
 	license?: string
 	organizationId?: string
@@ -66,6 +69,8 @@ export type ConfigurationOptions = {
 	chatBetweenGroups?: boolean
 	sessionVariables?: CustomerData['sessionVariables']
 	customIdentityProvider?: CustomIdentityProvider
+	/** @internal */
+	env?: Env
 }
 
 export type ChatData = {

--- a/packages/widget-core/tsconfig.json
+++ b/packages/widget-core/tsconfig.json
@@ -14,6 +14,7 @@
     "target": "ESNext",
     "moduleResolution": "node",
     "isolatedModules": true,
-    "importsNotUsedAsValues": "error"
+    "importsNotUsedAsValues": "error",
+    "stripInternal": true
   }
 }

--- a/packages/widget-react/src/LiveChatWidget.tsx
+++ b/packages/widget-react/src/LiveChatWidget.tsx
@@ -37,7 +37,7 @@ function Widget(props: WidgetConfig, product: ProductName) {
 			widgetRef.current?.destroy()
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [props.organizationId, props.license, props.group, props.chatBetweenGroups])
+	}, [props.organizationId, props.license, props.group, props.chatBetweenGroups, (props as { env?: string }).env])
 
 	React.useEffect(() => {
 		widgetRef.current?.updateVisibility(props.visibility)

--- a/packages/widget-vue/src/LiveChatWidget.ts
+++ b/packages/widget-vue/src/LiveChatWidget.ts
@@ -1,5 +1,4 @@
 import { defineComponent } from 'vue'
-import type { DefineComponent, ComponentOptionsMixin } from 'vue'
 import { createWidget } from '@livechat/widget-core'
 import type {
 	ExtendedWindow,
@@ -12,49 +11,12 @@ import type {
 
 declare const window: ExtendedWindow
 
-type EmitEvent =
-	| 'ready'
-	| 'new-event'
-	| 'form-submitted'
-	| 'rating-submitted'
-	| 'greeting-hidden'
-	| 'greeting-displayed'
-	| 'visibility-changed'
-	| 'customer-status-changed'
-	| 'rich-message-button-clicked'
-	| 'availability-changed'
-
-// `env` is internal-only, so it's kept out of PublicProps and cast away below despite being a real runtime prop.
-type PublicProps = {
-	license?: string
-	organizationId?: string
-	group?: string
-	visibility?: string
-	customerName?: string
-	customerEmail?: string
-	sessionVariables?: Record<string, string>
-	chatBetweenGroups?: boolean
-	customIdentityProvider?: WidgetConfig['customIdentityProvider']
-}
-
-type PublicWidgetComponent = DefineComponent<
-	PublicProps,
-	unknown,
-	{ widget: WidgetInstance | null },
-	Record<never, never>,
-	{ setupWidget(): void; reinitialize(): void },
-	ComponentOptionsMixin,
-	ComponentOptionsMixin,
-	EmitEvent[],
-	EmitEvent
->
-
 export const TextWidget = defineWidget('textapp')
 
 export const LiveChatWidget = defineWidget('livechat')
 
 function defineWidget(product: ProductName) {
-	const component = defineComponent({
+	return defineComponent({
 		props: {
 			license: {
 				type: String,
@@ -101,11 +63,14 @@ function defineWidget(product: ProductName) {
 				required: false,
 				default: undefined,
 			},
-			env: {
-				type: String,
-				required: false,
-				default: undefined,
-			},
+			// env is internal: cast hides it from the inferred props type, not from runtime
+			...({
+				env: {
+					type: String,
+					required: false,
+					default: undefined,
+				},
+			} as Record<never, never>),
 		},
 		emits: [
 			'ready',
@@ -162,7 +127,7 @@ function defineWidget(product: ProductName) {
 					chatBetweenGroups: this.chatBetweenGroups,
 					visibility: this.visibility as WidgetConfig['visibility'],
 					customIdentityProvider: this.customIdentityProvider as WidgetConfig['customIdentityProvider'],
-					env: this.env,
+					env: (this.$props as { env?: string }).env,
 					onReady: (data) => this.$emit('ready', data),
 					onNewEvent: (event) => this.$emit('new-event', event),
 					onFormSubmitted: (form) => this.$emit('form-submitted', form),
@@ -190,6 +155,4 @@ function defineWidget(product: ProductName) {
 			return null
 		},
 	})
-
-	return component as PublicWidgetComponent
 }

--- a/packages/widget-vue/src/LiveChatWidget.ts
+++ b/packages/widget-vue/src/LiveChatWidget.ts
@@ -1,4 +1,5 @@
 import { defineComponent } from 'vue'
+import type { DefineComponent, ComponentOptionsMixin } from 'vue'
 import { createWidget } from '@livechat/widget-core'
 import type {
 	ExtendedWindow,
@@ -11,12 +12,49 @@ import type {
 
 declare const window: ExtendedWindow
 
+type EmitEvent =
+	| 'ready'
+	| 'new-event'
+	| 'form-submitted'
+	| 'rating-submitted'
+	| 'greeting-hidden'
+	| 'greeting-displayed'
+	| 'visibility-changed'
+	| 'customer-status-changed'
+	| 'rich-message-button-clicked'
+	| 'availability-changed'
+
+// `env` is internal-only, so it's kept out of PublicProps and cast away below despite being a real runtime prop.
+type PublicProps = {
+	license?: string
+	organizationId?: string
+	group?: string
+	visibility?: string
+	customerName?: string
+	customerEmail?: string
+	sessionVariables?: Record<string, string>
+	chatBetweenGroups?: boolean
+	customIdentityProvider?: WidgetConfig['customIdentityProvider']
+}
+
+type PublicWidgetComponent = DefineComponent<
+	PublicProps,
+	unknown,
+	{ widget: WidgetInstance | null },
+	Record<never, never>,
+	{ setupWidget(): void; reinitialize(): void },
+	ComponentOptionsMixin,
+	ComponentOptionsMixin,
+	EmitEvent[],
+	EmitEvent
+>
+
 export const TextWidget = defineWidget('textapp')
 
 export const LiveChatWidget = defineWidget('livechat')
 
 function defineWidget(product: ProductName) {
-	return defineComponent({
+	const component = defineComponent({
 		props: {
 			license: {
 				type: String,
@@ -88,6 +126,7 @@ function defineWidget(product: ProductName) {
 		},
 		watch: {
 			license: 'reinitialize',
+			organizationId: 'reinitialize',
 			group: 'reinitialize',
 			chatBetweenGroups: 'reinitialize',
 			env: 'reinitialize',
@@ -151,4 +190,6 @@ function defineWidget(product: ProductName) {
 			return null
 		},
 	})
+
+	return component as PublicWidgetComponent
 }

--- a/packages/widget-vue/src/LiveChatWidget.ts
+++ b/packages/widget-vue/src/LiveChatWidget.ts
@@ -63,6 +63,11 @@ function defineWidget(product: ProductName) {
 				required: false,
 				default: undefined,
 			},
+			env: {
+				type: String,
+				required: false,
+				default: undefined,
+			},
 		},
 		emits: [
 			'ready',
@@ -85,6 +90,7 @@ function defineWidget(product: ProductName) {
 			license: 'reinitialize',
 			group: 'reinitialize',
 			chatBetweenGroups: 'reinitialize',
+			env: 'reinitialize',
 
 			visibility(visibility: WidgetState['visibility']) {
 				this.widget?.updateVisibility(visibility)
@@ -107,7 +113,7 @@ function defineWidget(product: ProductName) {
 		},
 		methods: {
 			setupWidget() {
-				this.widget = createWidget({
+				const config: WidgetConfig & { env?: string } = {
 					group: this.group,
 					license: this.license,
 					organizationId: this.organizationId,
@@ -117,6 +123,7 @@ function defineWidget(product: ProductName) {
 					chatBetweenGroups: this.chatBetweenGroups,
 					visibility: this.visibility as WidgetConfig['visibility'],
 					customIdentityProvider: this.customIdentityProvider as WidgetConfig['customIdentityProvider'],
+					env: this.env,
 					onReady: (data) => this.$emit('ready', data),
 					onNewEvent: (event) => this.$emit('new-event', event),
 					onFormSubmitted: (form) => this.$emit('form-submitted', form),
@@ -127,7 +134,8 @@ function defineWidget(product: ProductName) {
 					onCustomerStatusChanged: (status) => this.$emit('customer-status-changed', status),
 					onRichMessageButtonClicked: (button) => this.$emit('rich-message-button-clicked', button),
 					onAvailabilityChanged: (availability) => this.$emit('availability-changed', availability),
-				})
+				}
+				this.widget = createWidget(config)
 				window.__lc.integration_name = process.env.PACKAGE_NAME
 				if (product === 'textapp') {
 					window.__lc.product_name = 'text'


### PR DESCRIPTION
### Type of change

<!-- Check what type of PR it is by putting the 'x' sign in a bracket -->

- [ ] Docs
- [ ] Bug fix
- [x] Feature

### Packages

<!-- Check which package this PR affects by putting the 'x' sign in a bracket -->

- [x] @livechat/widget-core
- [x] @livechat/widget-react
- [x] @livechat/widget-vue
- [x] @livechat/widget-angular

### Issue

<!-- Paste here link to the issue that is resolved or fixed by this PR -->
https://livechatinc.atlassian.net/browse/IT-1810

### Description

<!-- Describe what changes this PR introduce -->
- Add an internal `env: 'labs' | 'staging' | 'production'` option (default `'production'`) to `@livechat/widget-core`, wired through `widget-react`, `widget-vue` and `widget-angular`, to control which `tracking.js` gets loaded
- Marked `@internal` and excluded from the published `.d.ts` via `stripInternal`
- `env` is read at call time from a module-level ref so it also applies correctly when the widget is reinitialized with a different value